### PR TITLE
Update Jobs v2 api to be more correct than it was

### DIFF
--- a/openapi-v3.yaml
+++ b/openapi-v3.yaml
@@ -970,9 +970,15 @@ components:
       required:
         - account_id
         - project_id
+        - id
         - environment_id
         - name
+        - dbt_version
+        - triggers
         - execute_steps
+        - settings
+        - state
+        - schedule
       properties:
         account_id:
           type: "integer"
@@ -980,6 +986,9 @@ components:
         project_id:
           type: "integer"
           example: 100
+        id:
+          type: [null]
+          example: 
         environment_id:
           type: "integer"
           example: 10
@@ -993,6 +1002,7 @@ components:
           example: 0.17.1
         triggers:
           type: "object"
+          example: {'github_webhook': false, 'schedule': true, 'custom_branch_only': false}
           properties:
             github_webhook:
               type: "boolean"
@@ -1007,6 +1017,7 @@ components:
             type: "string"
         settings:
           type: "object"
+          example: {'threads': 4, 'target_name': 'prod'}
           properties:
             threads:
               type: "integer"
@@ -1026,6 +1037,7 @@ components:
           description: When true, run a `dbt docs generate` step at the end of runs triggered from this job
         schedule:
           type: "object"
+          example: {'cron': '0 7 * * 1', 'date': {'type': 'every_day'}, 'time': {'interval': 1, 'type': 'every_hour'}}
           properties:
             cron:
               type: string
@@ -1040,6 +1052,8 @@ components:
             time:
               type: "object"
               properties:
+                interval:
+                  type: "integer"
                 type:
                   type: "string"
                   enum: ["every_hour", "at_exact_hours"]


### PR DESCRIPTION
Our v2 API docs aren't currently up to date, and have been more or less abandoned since May 2021.  This PR for the most part resolves [TRIAGE-62](https://dbtlabs.atlassian.net/browse/TRIAGE-62), which came about via a customer escalation, in that it documents what the required fields for the `JobDefinition` model are.  This largely was just for me to get an idea of how cumbersome it would be to go through and document all of our v2, and probably v3 as well, APIs.  While this PR doesn't fully bring our documentation inline for creating a Job, it gets it pretty close to matching what is defined in our codebase.  

Specific things to note: 
- The example response isn't 100% accurate at the moment.  
- Some nested attributes are optional
- Depending on the value of a nested attribute, e.g. whether the schedule time is `every_hour` vs. `at_exact_hours`, other fields may be required e.g. `hours`, and others should not be included e.g. `interval`.  Would need to look deeper into openapi to see what is supported and how we could look to represent that
- There are still yet some optional fields that could be passed in.  Unsure how many we might want to expose or not though.

**v2 Jobs create job API before:**
![Screen Shot 2022-04-04 at 2 36 27 PM](https://user-images.githubusercontent.com/16568275/161636927-c61b9839-2da7-47c1-ad1d-27aea09dd21c.png)




**v2 Jobs create job API after:**
![Screen Shot 2022-04-04 at 2 35 20 PM](https://user-images.githubusercontent.com/16568275/161636895-fcaf3e85-1c7b-4173-a75c-dcb2fd3a337b.png)
![Screen Shot 2022-04-04 at 2 35 27 PM](https://user-images.githubusercontent.com/16568275/161636900-d4504bd2-5591-40af-a393-6e3e4bbd9439.png)
![Screen Shot 2022-04-04 at 2 35 53 PM](https://user-images.githubusercontent.com/16568275/161636913-a57f1b3f-d7e8-4eb2-97ee-fe48cf570b98.png)

