### PR TITLE
[AAI-461] Deprecate /accounts/{id}/steps/ endpoint

### DIFF
--- a/openapi-v3.yaml
+++ b/openapi-v3.yaml
@@ -742,7 +742,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-                
+
         '404':
           description: Unauthorized or Not Found.
           content:
@@ -751,10 +751,14 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /accounts/{accountId}/steps/:
     get:
+      deprecated: true
       tags:
         - Runs
       summary: List steps
-      description: Fetch information about all steps in an account
+      description: |
+        This method is deprecated, please use `include_related=["run_steps"]` on the
+        `GET /accounts/{accountId}/runs/{runId}/` endpoint instead to fetch steps
+        within a specific run.
       operationId: listSteps
       parameters:
         - $ref: '#/components/parameters/accountId'


### PR DESCRIPTION
<img width="1565" alt="Screen Shot 2022-09-14 at 10 54 58 AM" src="https://user-images.githubusercontent.com/200728/190189879-e733f1fe-38b3-4256-9b1b-76f71b1e95f9.png">

This deprecates the `/accounts/{accountId}/steps/` endpoint in the official docs in favor of using `include_related=["run_steps"]` on a particular run.