### PR TITLE
Linking to the migrating to v2 docs

### DIFF
--- a/openapi-v4.yaml
+++ b/openapi-v4.yaml
@@ -7,7 +7,7 @@ info:
 
     # Deprecation Notice
     dbt Cloud API v4 will be DEPRECATED by April 30th, 2023. We are advising migration to 
-    dbt Cloud API v2 and will be providing guidance docs soon. In the interim, support for 
+    dbt Cloud API v2. You can find out more in [Migrating to dbt Cloud Administrative API v2](https://docs.getdbt.com/docs/dbt-cloud-apis/migrating-to-v2). In the interim, support for 
     partners can be provided via shared Slack channels or reaching out to partnerships@dbtlabs.com. 
     All other users can reach out to dbt Support https://docs.getdbt.com/docs/dbt-support.
 

--- a/openapi-v4.yaml
+++ b/openapi-v4.yaml
@@ -7,9 +7,9 @@ info:
 
     # Deprecation Notice
     dbt Cloud API v4 will be DEPRECATED by April 30th, 2023. We are advising migration to 
-    dbt Cloud API v2. You can find out more in [Migrating to dbt Cloud Administrative API v2](https://docs.getdbt.com/docs/dbt-cloud-apis/migrating-to-v2). In the interim, support for 
-    partners can be provided via shared Slack channels or reaching out to partnerships@dbtlabs.com. 
-    All other users can reach out to dbt Support https://docs.getdbt.com/docs/dbt-support.
+    dbt Cloud API v2. You can find out more in [Migrating to dbt Cloud Administrative API v2](https://docs.getdbt.com/docs/dbt-cloud-apis/migrating-to-v2). If you need further help, support for 
+    partners can be provided using shared Slack channels or reaching out to partnerships@dbtlabs.com. 
+    All others can reach out to [dbt Support](https://docs.getdbt.com/docs/dbt-support).
 
     # Authentication
 


### PR DESCRIPTION
Hey @iktl I updated the deprecation notice link to point to the new page on migrating from v4 to v2. Can you review this and let me know if we can merge it?

