### PR TITLE
run: add list of supported order_by values

### DIFF
--- a/openapi-v3.yaml
+++ b/openapi-v3.yaml
@@ -581,6 +581,14 @@ paths:
           example: "-id"
           schema:
             type: string
+            default: id
+            enum:
+              - id
+              - -id
+              - created_at
+              - -created_at
+              - finished_at
+              - -finished_at
           description: |
             Field to order the result by. Use `-` to indicate reverse order.
         - in: query


### PR DESCRIPTION
### Description
We are restricting order_by values on Runs API endpoints. This PR adds currently supported values for `order_by` parameter. 

### Tests
Before:
![Screenshot 2023-04-06 at 10 04 29 AM](https://user-images.githubusercontent.com/4484507/230401794-b47f3826-7ea7-4666-9b0e-3c06fcf0ef80.png)
After:
![Screenshot 2023-04-06 at 10 04 40 AM](https://user-images.githubusercontent.com/4484507/230401839-1a66b56c-1c8b-4a38-8d24-83286260507b.png)
