### PR TITLE
change packages.yml to manifest.json with top level keys

### DIFF
--- a/openapi-v3.yaml
+++ b/openapi-v3.yaml
@@ -767,14 +767,20 @@ paths:
               schema:
                 type: string
                 description: Raw file contents product by dbt
-                example: "# package.yaml
-                  packages:
-                  - package: dbt-labs/audit_helper
-                  version: 0.5.0
-                  - package: dbt-labs/codegen
-                  version: 0.5.0
-                  - package: dbt-labs/dbt_utils
-                  version: 0.8.2"
+                example: "# 'manifest.json'
+                  {
+                    'metadata' : { ... },
+                    'nodes' : { ... },
+                    'sources' : { ... },
+                    'macros' : { ... },
+                    'docs' : { ... },
+                    'exposures' : { ... },
+                    'metrics' : { ... },
+                    'selectors' : { ... },
+                    'disabled' : { ... },
+                    'parent_map' : { ... },
+                    'child_map' : { ... }
+                  }"
         '400':
           description: Bad Request.
           content:


### PR DESCRIPTION
user in the community reported erroneous example for the artifact endpoint, which shows retrieval of `packages.yml` , which is not an available artifact. Updated to show top level keys of manifest.json instead!