### PR TITLE
Fix API auth and auto generate descriptions

### DIFF
--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -2,63 +2,35 @@ openapi: 3.0.3
 info:
   title: dbt Cloud API v2
   version: 2.0.0
-  description: |
-    The dbt Cloud API makes it possible to fetch data from your
-    dbt Cloud account and programmatically run and monitor dbt jobs.
-
-    # How to use this API
-
-    The dbt Cloud API is intended for enqueuing runs from a job, polling for run progress,
-    and downloading artifacts after jobs have completed running. Operational endpoints around
-    creating, modifying, and deleting _objects_ in dbt Cloud are still in flux. These endpoints
-    are largely undocumented in API v2.
-
-    The API docs are generated from an openapi spec defined in the
-    [dbt-cloud-openapi-spec](https://github.com/fishtown-analytics/dbt-cloud-openapi-spec)
-    repository. If you find issues in these docs or have questions about using the dbt Cloud
-    API, please open an issue in the dbt-cloud-openapi-spec repo or contact support@getdbt.com.
-
-    # Authentication
-
-    To authenticate an application with the dbt Cloud API, navigate to the
-    API Settings page in your [dbt Cloud profile](https://cloud.getdbt.com/#/profile/api/).
-    If you cannot access this page, confirm that your dbt Cloud account has access to the API,
-    and that you are using the hosted version of dbt Cloud. If dbt Cloud is running inside of a VPC
-    in an Enterprise account, contact your account manager for help finding your API key.
-
-    ## TokenAuth
-
-    Once you've found your API key, use it in the Authorization header of requests to the dbt Cloud API.
-    Be sure to include the `Token` prefix in the Authorization header, or the request will fail with a
-    "401 Unauthorized" error. Note: `Bearer` can be used in place of `Token` in the Authorization header.
-    Both syntaxes are equivalent.
-
-    **Headers**
-    ```
-    Accept: application/json
-    Authorization: Token <your token>
-    ```
-
-    ## Example request
-
-    The following example will list the Accounts that your token is authorized to access.
-    Be sure to replace `<your token>` in the Authorization header with your actual API token.
-
-    ```
-    curl --request GET \
-      --url https://cloud.getdbt.com/api/v2/accounts/ \
-      --header 'Content-Type: application/json' \
-      --header 'Authorization: Token <your token>'
-    ```
-
-    # Pagination
-
-    All top-level API resources have support for bulk fetches via "list" API methods. These list
-    API methods accept `limit` and `offset` query parameters which can be used together to paginate results.
-
-    Offsets begin at 0.
-
-    The maximum limit for a single request is 100.
+  description: "# How to use this API\n\nThe dbt Cloud API is intended for enqueuing\
+    \ runs from a job, polling for run progress,\nand downloading artifacts after\
+    \ jobs have completed running. Operational endpoints around\ncreating, modifying,\
+    \ and deleting _objects_ in dbt Cloud are still in flux. These endpoints\nare\
+    \ largely undocumented in API v2.\n\nThe API docs are generated from an openapi\
+    \ spec defined in the\n[dbt-cloud-openapi-spec](https://github.com/dbt-labs/dbt-cloud-openapi-spec)\n\
+    repository. If you find issues in these docs or have questions about using the\
+    \ dbt Cloud\nAPI, please open an issue in the dbt-cloud-openapi-spec repo or contact\
+    \ support@getdbt.com.\n\n# Authentication\n\nTo authenticate an application with\
+    \ the dbt Cloud API, navigate to the\nAPI Settings page in your [dbt Cloud profile](https://cloud.getdbt.com/#/profile/api/).\n\
+    If you cannot access this page, confirm that your dbt Cloud account has access\
+    \ to the API,\nand that you are using the hosted version of dbt Cloud. If dbt\
+    \ Cloud is running inside of a VPC\nin an Enterprise account, contact your account\
+    \ manager for help finding your API key.\n\n## Token Auth\n\nOnce you've found\
+    \ your API key, use it in the Authorization header of requests to the dbt Cloud\
+    \ API.\nBe sure to include the `Token` prefix in the Authorization header, or\
+    \ the request will fail with a\n\"401 Unauthorized\" error. Note: `Bearer` can\
+    \ be used in place of `Token` in the Authorization header.\nBoth syntaxes are\
+    \ equivalent.\n\n**Headers**\n```\nAccept: application/json\nAuthorization: Token\
+    \ <your token>\n```\n\n## Example request\n\nThe following example will list the\
+    \ Accounts that your token is authorized to access.\nBe sure to replace `<your\
+    \ token>` in the Authorization header with your actual API token.\n\n```bash\n\
+    curl --request GET \\\n  --url https://cloud.getdbt.com/api/v2/accounts/ \\\n\
+    \  --header 'Content-Type: application/json' \\\n  --header 'Authorization: Token\
+    \ <your token>'\n```\n\n&nbsp;  \n\n# Pagination\n\nAll top-level API resources\
+    \ have support for bulk fetches via \"list\" API methods. These list\nAPI methods\
+    \ accept `limit` and `offset` query parameters which can be used together to paginate\
+    \ results.\n\nOffsets begin at 0.\n\nThe maximum limit for a single request is\
+    \ 100.\n"
   termsOfService: https://www.getdbt.com/terms-of-service
   contact:
     email: support@getdbt.com
@@ -92,7 +64,7 @@ paths:
       tags:
       - Connections
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -125,7 +97,7 @@ paths:
               $ref: '#/components/schemas/BaseConnectionRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -169,7 +141,7 @@ paths:
       tags:
       - Connections
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -205,7 +177,7 @@ paths:
               $ref: '#/components/schemas/BaseConnectionRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -246,7 +218,7 @@ paths:
       tags:
       - Connections
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -286,7 +258,7 @@ paths:
       tags:
       - Connection Encryptions
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -319,7 +291,7 @@ paths:
               $ref: '#/components/schemas/ConnectionEncryptionRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -370,7 +342,7 @@ paths:
       tags:
       - Connection Encryptions
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -406,7 +378,7 @@ paths:
               $ref: '#/components/schemas/ConnectionEncryptionRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -454,7 +426,7 @@ paths:
       tags:
       - Connection Encryptions
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -491,7 +463,7 @@ paths:
       tags:
       - Environments
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -524,7 +496,7 @@ paths:
               $ref: '#/components/schemas/EnvironmentV2Request'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -572,7 +544,7 @@ paths:
       tags:
       - Environments
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -608,7 +580,7 @@ paths:
               $ref: '#/components/schemas/EnvironmentV2Request'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -653,7 +625,7 @@ paths:
       tags:
       - Environments
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -669,7 +641,7 @@ paths:
       tags:
       - Invites
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -690,7 +662,7 @@ paths:
       tags:
       - Invites
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -710,7 +682,7 @@ paths:
       tags:
       - Invites
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -783,7 +755,7 @@ paths:
       tags:
       - Jobs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -816,7 +788,7 @@ paths:
               $ref: '#/components/schemas/InternalJobDefinitionRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -850,7 +822,7 @@ paths:
       tags:
       - Jobs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -888,7 +860,7 @@ paths:
               $ref: '#/components/schemas/TriggerRunRequestRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -970,7 +942,7 @@ paths:
       tags:
       - Jobs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1006,7 +978,7 @@ paths:
               $ref: '#/components/schemas/InternalJobDefinitionRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1087,7 +1059,7 @@ paths:
       tags:
       - Jobs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -1103,7 +1075,7 @@ paths:
       tags:
       - Licenses
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -1136,7 +1108,7 @@ paths:
       tags:
       - Notifications
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1169,7 +1141,7 @@ paths:
               $ref: '#/components/schemas/JobNotificationSettingsRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1213,7 +1185,7 @@ paths:
       tags:
       - Notifications
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1249,7 +1221,7 @@ paths:
               $ref: '#/components/schemas/JobNotificationSettingsRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1290,7 +1262,7 @@ paths:
       tags:
       - Notifications
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -1311,7 +1283,7 @@ paths:
       tags:
       - Permissions
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -1355,7 +1327,7 @@ paths:
       tags:
       - Projects
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1388,7 +1360,7 @@ paths:
               $ref: '#/components/schemas/ProjectRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1443,7 +1415,7 @@ paths:
       tags:
       - Projects
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1479,7 +1451,7 @@ paths:
               $ref: '#/components/schemas/ProjectRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1531,7 +1503,7 @@ paths:
       tags:
       - Projects
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -1568,7 +1540,7 @@ paths:
       tags:
       - Repositories
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1601,7 +1573,7 @@ paths:
               $ref: '#/components/schemas/RepositoryV2Request'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1649,7 +1621,7 @@ paths:
       tags:
       - Repositories
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1694,7 +1666,7 @@ paths:
       tags:
       - Repositories
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -1778,7 +1750,7 @@ paths:
       tags:
       - Runs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1873,7 +1845,7 @@ paths:
       tags:
       - Runs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1898,7 +1870,7 @@ paths:
       tags:
       - Runs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -1940,7 +1912,7 @@ paths:
       tags:
       - Runs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -1961,7 +1933,7 @@ paths:
       tags:
       - Runs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -1982,7 +1954,7 @@ paths:
       tags:
       - Runs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -1998,7 +1970,7 @@ paths:
       tags:
       - Users
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2008,7 +1980,7 @@ paths:
       tags:
       - Notifications
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2041,7 +2013,7 @@ paths:
       tags:
       - Users
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -2072,7 +2044,7 @@ paths:
               $ref: '#/components/schemas/UserRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -2523,6 +2495,12 @@ components:
           type: boolean
         run_failure_count:
           type: integer
+        job_type:
+          oneOf:
+          - {}
+          - {}
+          - {}
+          - type: 'null'
       additionalProperties: false
       definitions: {}
       $schema: http://json-schema.org/draft-07/schema#
@@ -2623,6 +2601,12 @@ components:
           type: boolean
         run_failure_count:
           type: integer
+        job_type:
+          oneOf:
+          - {}
+          - {}
+          - {}
+          - type: 'null'
       additionalProperties: false
       definitions: {}
       $schema: http://json-schema.org/draft-07/schema#
@@ -4924,6 +4908,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -4939,7 +4931,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -5355,10 +5348,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -8792,6 +8781,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -8807,7 +8804,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -9223,10 +9221,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -10843,11 +10837,6 @@ components:
           - type: boolean
           - type: 'null'
           readOnly: true
-        href:
-          oneOf:
-          - type: string
-          - type: 'null'
-          readOnly: true
         duration:
           oneOf:
           - type: string
@@ -11438,11 +11427,10 @@ components:
       definitions: {}
       $schema: http://json-schema.org/draft-07/schema#
   securitySchemes:
-    tokenAuth:
-      type: apiKey
-      in: header
-      name: Authorization
-      description: Token-based authentication with required prefix "Token"
+    BearerAuthentication:
+      type: http
+      scheme: bearer
+      bearerFormat: Bearer
 servers:
 - url: https://cloud.getdbt.com/
   description: Production (US)

--- a/openapi-v3.yaml
+++ b/openapi-v3.yaml
@@ -2,63 +2,35 @@ openapi: 3.0.3
 info:
   title: dbt Cloud API v3
   version: 3.0.0
-  description: |
-    The dbt Cloud API makes it possible to fetch data from your
-    dbt Cloud account and programmatically run and monitor dbt jobs.
-
-    # How to use this API
-
-    The dbt Cloud API is intended for enqueuing runs from a job, polling for run progress,
-    and downloading artifacts after jobs have completed running. Operational endpoints around
-    creating, modifying, and deleting _objects_ in dbt Cloud are still in flux. These endpoints
-    are largely undocumented in API v2.
-
-    The API docs are generated from an openapi spec defined in the
-    [dbt-cloud-openapi-spec](https://github.com/fishtown-analytics/dbt-cloud-openapi-spec)
-    repository. If you find issues in these docs or have questions about using the dbt Cloud
-    API, please open an issue in the dbt-cloud-openapi-spec repo or contact support@getdbt.com.
-
-    # Authentication
-
-    To authenticate an application with the dbt Cloud API, navigate to the
-    API Settings page in your [dbt Cloud profile](https://cloud.getdbt.com/#/profile/api/).
-    If you cannot access this page, confirm that your dbt Cloud account has access to the API,
-    and that you are using the hosted version of dbt Cloud. If dbt Cloud is running inside of a VPC
-    in an Enterprise account, contact your account manager for help finding your API key.
-
-    ## TokenAuth
-
-    Once you've found your API key, use it in the Authorization header of requests to the dbt Cloud API.
-    Be sure to include the `Token` prefix in the Authorization header, or the request will fail with a
-    "401 Unauthorized" error. Note: `Bearer` can be used in place of `Token` in the Authorization header.
-    Both syntaxes are equivalent.
-
-    **Headers**
-    ```
-    Accept: application/json
-    Authorization: Token <your token>
-    ```
-
-    ## Example request
-
-    The following example will list the Accounts that your token is authorized to access.
-    Be sure to replace `<your token>` in the Authorization header with your actual API token.
-
-    ```
-    curl --request GET \
-      --url https://cloud.getdbt.com/api/v2/accounts/ \
-      --header 'Content-Type: application/json' \
-      --header 'Authorization: Token <your token>'
-    ```
-
-    # Pagination
-
-    All top-level API resources have support for bulk fetches via "list" API methods. These list
-    API methods accept `limit` and `offset` query parameters which can be used together to paginate results.
-
-    Offsets begin at 0.
-
-    The maximum limit for a single request is 100.
+  description: "# How to use this API\n\nThe dbt Cloud API is intended for enqueuing\
+    \ runs from a job, polling for run progress,\nand downloading artifacts after\
+    \ jobs have completed running. Operational endpoints around\ncreating, modifying,\
+    \ and deleting _objects_ in dbt Cloud are still in flux. These endpoints\nare\
+    \ largely undocumented in API v2.\n\nThe API docs are generated from an openapi\
+    \ spec defined in the\n[dbt-cloud-openapi-spec](https://github.com/dbt-labs/dbt-cloud-openapi-spec)\n\
+    repository. If you find issues in these docs or have questions about using the\
+    \ dbt Cloud\nAPI, please open an issue in the dbt-cloud-openapi-spec repo or contact\
+    \ support@getdbt.com.\n\n# Authentication\n\nTo authenticate an application with\
+    \ the dbt Cloud API, navigate to the\nAPI Settings page in your [dbt Cloud profile](https://cloud.getdbt.com/#/profile/api/).\n\
+    If you cannot access this page, confirm that your dbt Cloud account has access\
+    \ to the API,\nand that you are using the hosted version of dbt Cloud. If dbt\
+    \ Cloud is running inside of a VPC\nin an Enterprise account, contact your account\
+    \ manager for help finding your API key.\n\n## Token Auth\n\nOnce you've found\
+    \ your API key, use it in the Authorization header of requests to the dbt Cloud\
+    \ API.\nBe sure to include the `Token` prefix in the Authorization header, or\
+    \ the request will fail with a\n\"401 Unauthorized\" error. Note: `Bearer` can\
+    \ be used in place of `Token` in the Authorization header.\nBoth syntaxes are\
+    \ equivalent.\n\n**Headers**\n```\nAccept: application/json\nAuthorization: Token\
+    \ <your token>\n```\n\n## Example request\n\nThe following example will list the\
+    \ Accounts that your token is authorized to access.\nBe sure to replace `<your\
+    \ token>` in the Authorization header with your actual API token.\n\n```bash\n\
+    curl --request GET \\\n  --url https://cloud.getdbt.com/api/v2/accounts/ \\\n\
+    \  --header 'Content-Type: application/json' \\\n  --header 'Authorization: Token\
+    \ <your token>'\n```\n\n&nbsp;  \n\n# Pagination\n\nAll top-level API resources\
+    \ have support for bulk fetches via \"list\" API methods. These list\nAPI methods\
+    \ accept `limit` and `offset` query parameters which can be used together to paginate\
+    \ results.\n\nOffsets begin at 0.\n\nThe maximum limit for a single request is\
+    \ 100.\n"
   termsOfService: https://www.getdbt.com/terms-of-service
   contact:
     email: support@getdbt.com
@@ -70,7 +42,7 @@ paths:
       tags:
       - Accounts
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -90,7 +62,7 @@ paths:
       tags:
       - Groups
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -107,7 +79,7 @@ paths:
       tags:
       - Audit Logs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -124,7 +96,7 @@ paths:
       tags:
       - Audit Logs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -140,7 +112,7 @@ paths:
       tags:
       - Audit Logs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -156,7 +128,7 @@ paths:
       tags:
       - Audit Logs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -177,7 +149,7 @@ paths:
       tags:
       - Audit Logs
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -195,7 +167,7 @@ paths:
       tags:
       - Codex Token
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -216,7 +188,7 @@ paths:
       tags:
       - Groups
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -264,7 +236,7 @@ paths:
       tags:
       - Groups
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -297,7 +269,7 @@ paths:
               $ref: '#/components/schemas/GroupRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -356,7 +328,7 @@ paths:
       tags:
       - Groups
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -392,7 +364,7 @@ paths:
               $ref: '#/components/schemas/GroupRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -412,7 +384,7 @@ paths:
       tags:
       - Invites
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -448,7 +420,7 @@ paths:
       tags:
       - License Maps
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -481,7 +453,7 @@ paths:
               $ref: '#/components/schemas/LicenseMapRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -528,7 +500,7 @@ paths:
       tags:
       - License Maps
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -564,7 +536,7 @@ paths:
               $ref: '#/components/schemas/LicenseMapRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -608,7 +580,7 @@ paths:
       tags:
       - License Maps
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -624,7 +596,7 @@ paths:
       tags:
       - Private Link Endpoints
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -668,7 +640,7 @@ paths:
       tags:
       - Projects
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -701,7 +673,7 @@ paths:
               $ref: '#/components/schemas/ProjectRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -756,7 +728,7 @@ paths:
       tags:
       - Projects
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -792,7 +764,7 @@ paths:
               $ref: '#/components/schemas/ProjectRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -844,7 +816,7 @@ paths:
       tags:
       - Projects
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -893,7 +865,7 @@ paths:
       tags:
       - Projects Adapters
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -931,7 +903,7 @@ paths:
               $ref: '#/components/schemas/DbtAdapterRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -991,7 +963,7 @@ paths:
       tags:
       - Projects Adapters
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1032,7 +1004,7 @@ paths:
               $ref: '#/components/schemas/DbtAdapterRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1089,7 +1061,7 @@ paths:
       tags:
       - Projects Adapters
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -1112,7 +1084,7 @@ paths:
       tags:
       - Projects Codex Token
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -1161,7 +1133,7 @@ paths:
       tags:
       - Connections
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1199,7 +1171,7 @@ paths:
               $ref: '#/components/schemas/BaseConnectionV3Request'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1259,7 +1231,7 @@ paths:
       tags:
       - Connections
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1300,7 +1272,7 @@ paths:
               $ref: '#/components/schemas/BaseConnectionV3Request'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1357,7 +1329,7 @@ paths:
       tags:
       - Connections
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -1406,7 +1378,7 @@ paths:
       tags:
       - Credentials
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -1426,7 +1398,7 @@ paths:
       tags:
       - Credentials
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -1480,7 +1452,7 @@ paths:
       tags:
       - Credentials
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -1505,7 +1477,7 @@ paths:
       tags:
       - Credentials
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -1562,7 +1534,7 @@ paths:
       tags:
       - Credentials
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -1615,7 +1587,7 @@ paths:
       tags:
       - Credentials
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -1648,7 +1620,7 @@ paths:
               $ref: '#/components/schemas/CustomEnvironmentVariableRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1692,7 +1664,7 @@ paths:
               $ref: '#/components/schemas/CustomEnvironmentVariableRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1769,7 +1741,7 @@ paths:
       tags:
       - Environment Variables
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -1789,8 +1761,20 @@ paths:
         required: true
       tags:
       - Environment Variables
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomEnvironmentVariableRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CustomEnvironmentVariableRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CustomEnvironmentVariableRequest'
+        required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1813,8 +1797,20 @@ paths:
         required: true
       tags:
       - Environment Variables
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomEnvironmentVariableRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CustomEnvironmentVariableRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CustomEnvironmentVariableRequest'
+        required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1838,7 +1834,7 @@ paths:
       tags:
       - Environment Variables
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -1907,7 +1903,7 @@ paths:
       tags:
       - Environment Variables
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -1982,7 +1978,7 @@ paths:
       tags:
       - Environment Variables
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -2057,7 +2053,7 @@ paths:
       tags:
       - Environment Variables
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -2144,7 +2140,7 @@ paths:
       tags:
       - Environments
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -2182,7 +2178,7 @@ paths:
               $ref: '#/components/schemas/EnvironmentV3Request'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -2274,7 +2270,7 @@ paths:
       tags:
       - Environments
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -2315,7 +2311,7 @@ paths:
               $ref: '#/components/schemas/EnvironmentV3Request'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -2404,7 +2400,7 @@ paths:
       tags:
       - Environments
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -2425,7 +2421,7 @@ paths:
       tags:
       - Groups
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2478,7 +2474,7 @@ paths:
       tags:
       - Repositories
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -2516,7 +2512,7 @@ paths:
               $ref: '#/components/schemas/RepositoryV3Request'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -2580,7 +2576,7 @@ paths:
       tags:
       - Repositories
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -2621,7 +2617,7 @@ paths:
               $ref: '#/components/schemas/RepositoryV3Request'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -2682,7 +2678,7 @@ paths:
       tags:
       - Repositories
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -2698,7 +2694,7 @@ paths:
       tags:
       - Service Tokens
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2714,7 +2710,7 @@ paths:
       tags:
       - Service Tokens
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2735,7 +2731,7 @@ paths:
       tags:
       - Service Tokens
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2755,7 +2751,7 @@ paths:
       tags:
       - Service Tokens
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2775,7 +2771,7 @@ paths:
       tags:
       - Service Tokens
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -2796,7 +2792,7 @@ paths:
       tags:
       - Service Tokens
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2816,7 +2812,7 @@ paths:
       tags:
       - Service Tokens
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2832,7 +2828,7 @@ paths:
       tags:
       - Users
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2853,7 +2849,7 @@ paths:
       tags:
       - Webhooks
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2874,7 +2870,7 @@ paths:
       tags:
       - Webhooks
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2895,7 +2891,7 @@ paths:
       tags:
       - Webhooks
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2916,7 +2912,7 @@ paths:
       tags:
       - Webhooks
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2936,7 +2932,7 @@ paths:
       tags:
       - Webhooks
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2956,7 +2952,7 @@ paths:
       tags:
       - Webhooks
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -2977,7 +2973,7 @@ paths:
       tags:
       - Webhooks
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -2998,7 +2994,7 @@ paths:
       tags:
       - Webhooks
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -3014,7 +3010,7 @@ paths:
       tags:
       - Webhooks
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -3029,7 +3025,7 @@ paths:
       tags:
       - Webhooks
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -3039,7 +3035,7 @@ paths:
       tags:
       - Adapter Schema
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           description: No response body
@@ -3083,7 +3079,7 @@ paths:
       tags:
       - Users
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -3116,7 +3112,7 @@ paths:
               $ref: '#/components/schemas/UserCredentialsRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -3171,7 +3167,7 @@ paths:
       tags:
       - Users
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -3207,7 +3203,7 @@ paths:
               $ref: '#/components/schemas/UserCredentialsRequest'
         required: true
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '200':
           content:
@@ -3259,7 +3255,7 @@ paths:
       tags:
       - Users
       security:
-      - tokenAuth: []
+      - BearerAuthentication: []
       responses:
         '204':
           description: No response body
@@ -5589,6 +5585,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -5604,7 +5608,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -6020,10 +6025,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -9433,6 +9434,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -9448,7 +9457,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -9864,10 +9874,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -13313,6 +13319,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -13328,7 +13342,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -13744,10 +13759,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -17163,6 +17174,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -17178,7 +17197,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -17594,10 +17614,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -21002,6 +21018,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -21017,7 +21041,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -21433,10 +21458,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -24837,6 +24858,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -24852,7 +24881,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -25268,10 +25298,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -28725,6 +28751,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -28740,7 +28774,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -29159,10 +29194,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -32598,6 +32629,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -32613,7 +32652,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -32995,10 +33035,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -36776,6 +36812,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -36791,7 +36835,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -37207,10 +37252,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -40644,6 +40685,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -40659,7 +40708,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -41075,10 +41125,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -44573,6 +44619,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -44588,7 +44642,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -45004,10 +45059,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -48482,6 +48533,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -48497,7 +48556,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -48913,10 +48973,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -52403,6 +52459,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -52418,7 +52482,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -52834,10 +52899,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -56253,6 +56314,14 @@ components:
                 items:
                   $ref: '#/definitions/CustomEnvironmentVariable'
               - type: 'null'
+            job_type:
+              oneOf:
+              - type: string
+                enum:
+                - ci
+                - scheduled
+                - other
+              - type: 'null'
           additionalProperties: false
           description: 'JobDefinitionV2(environment_id: int, account_id: int, project_id:
             int, name: str, generate_docs: bool, run_generate_sources: bool, state:
@@ -56268,7 +56337,8 @@ components:
             = None, most_recent_run: Union[models.run.Run, NoneType] = None, most_recent_completed_run:
             Union[models.run.Run, NoneType] = None, custom_environment_variables:
             Union[List[models.custom_environment_variable.CustomEnvironmentVariable],
-            NoneType] = None)'
+            NoneType] = None, job_type: Union[common.constants.JobType, NoneType]
+            = None)'
         JobDefinitionTriggers:
           type: object
           required:
@@ -56684,10 +56754,6 @@ components:
             is_cancelled:
               oneOf:
               - type: boolean
-              - type: 'null'
-            href:
-              oneOf:
-              - type: string
               - type: 'null'
             duration:
               oneOf:
@@ -57906,11 +57972,10 @@ components:
             \ in both the IDE and\n    scheduled Runs.\n    "
       $schema: http://json-schema.org/draft-07/schema#
   securitySchemes:
-    tokenAuth:
-      type: apiKey
-      in: header
-      name: Authorization
-      description: Token-based authentication with required prefix "Token"
+    BearerAuthentication:
+      type: http
+      scheme: bearer
+      bearerFormat: Bearer
 servers:
 - url: https://cloud.getdbt.com/
   description: Production (US)


### PR DESCRIPTION
1. Updates auth type to use correct bearer token method. This now gets set automatically during "Try It" requests
2. Updates descriptions to be auto generated

- [x] Try it requests work
- [x] Auth is now properly documented
- [x] Descriptions show up properly still even after auto generation
- [x] Tested out new specs in spotlight elements to make sure things look good post generation: https://elements-demo.stoplight.io/?spec=https://raw.githubusercontent.com/dbt-labs/dbt-cloud-openapi-spec/3d25048daf515be76a6a136965133e6f9c903084/openapi-v2.yaml