### PR TITLE
update docs to remove filters where they are not used

### DIFF
--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -184,9 +184,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ConnectionEncryptionEnveloped'
+                $ref: '#/components/schemas/ConnectionEncryptionEnveloped'
           description: ''
   /api/v2/accounts/{account_id}/encryptions/{id}/:
     get:
@@ -198,35 +196,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: connection_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Connections
       security:
@@ -284,35 +258,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: connection_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Connections
       security:
@@ -411,9 +361,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/EnvironmentV2Enveloped'
+                $ref: '#/components/schemas/EnvironmentV2Enveloped'
           description: ''
   /api/v2/accounts/{account_id}/environments/{id}/:
     get:
@@ -425,47 +373,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: dbt_version
-        schema:
-          type: string
-      - in: query
-        name: dbt_version__in
-        schema:
-          type: array
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Environments
       security:
@@ -525,47 +437,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: dbt_version
-        schema:
-          type: string
-      - in: query
-        name: dbt_version__in
-        schema:
-          type: array
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Environments
       security:
@@ -716,9 +592,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HumanReadableJobDefinitionEnveloped'
+                $ref: '#/components/schemas/HumanReadableJobDefinitionEnveloped'
           description: ''
   /api/v2/accounts/{account_id}/jobs/{job_id}/artifacts/{remainder}:
     get:
@@ -747,11 +621,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            text/html:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v2/accounts/{account_id}/jobs/{job_id}/rerun/:
     post:
       operationId: Retry Failed Job
@@ -778,11 +648,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v2/accounts/{account_id}/jobs/{job_id}/run/:
     post:
       operationId: Trigger Job Run
@@ -835,55 +701,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: dbt_version__in
-        schema:
-          type: array
-      - in: query
-        name: environment_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: name__icontains
-        schema:
-          type: string
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
-      - in: query
-        name: triggers_schedule
-        schema:
-          type: boolean
       tags:
       - Jobs
       security:
@@ -941,55 +763,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: dbt_version__in
-        schema:
-          type: array
-      - in: query
-        name: environment_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: name__icontains
-        schema:
-          type: string
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
-      - in: query
-        name: triggers_schedule
-        schema:
-          type: boolean
       tags:
       - Jobs
       security:
@@ -1012,11 +790,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v2/accounts/{account_id}/notifications/:
     get:
       operationId: List Notifications
@@ -1108,9 +882,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/JobNotificationSettingsEnveloped'
+                $ref: '#/components/schemas/JobNotificationSettingsEnveloped'
           description: ''
   /api/v2/accounts/{account_id}/notifications/{id}/:
     get:
@@ -1122,47 +894,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: external_email
-        schema:
-          type: string
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: slack_channel_id
-        schema:
-          type: string
-      - in: query
-        name: state
-        schema:
-          type: integer
-      - in: query
-        name: type
-        schema:
-          type: integer
-      - in: query
-        name: user_id
-        schema:
-          type: integer
       tags:
       - Notifications
       security:
@@ -1219,47 +955,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: external_email
-        schema:
-          type: string
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: slack_channel_id
-        schema:
-          type: string
-      - in: query
-        name: state
-        schema:
-          type: integer
-      - in: query
-        name: type
-        schema:
-          type: integer
-      - in: query
-        name: user_id
-        schema:
-          type: integer
       tags:
       - Notifications
       security:
@@ -1287,11 +987,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v2/accounts/{account_id}/projects/:
     get:
       operationId: List Projects
@@ -1375,9 +1071,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ProjectEnveloped'
+                $ref: '#/components/schemas/ProjectEnveloped'
           description: ''
   /api/v2/accounts/{account_id}/projects/{id}/:
     get:
@@ -1389,39 +1083,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: name__icontains
-        schema:
-          type: string
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: pk__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Projects
       security:
@@ -1481,39 +1147,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: name__icontains
-        schema:
-          type: string
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: pk__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Projects
       security:
@@ -1609,9 +1247,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RepositoryV2Enveloped'
+                $ref: '#/components/schemas/RepositoryV2Enveloped'
           description: ''
   /api/v2/accounts/{account_id}/repositories/{id}/:
     get:
@@ -1623,43 +1259,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: remote_url
-        schema:
-          type: string
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Repositories
       security:
@@ -1681,43 +1285,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: remote_url
-        schema:
-          type: string
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Repositories
       security:
@@ -1835,87 +1407,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: created_at__range
-        schema:
-          type: array
-      - in: query
-        name: dbt_version
-        schema:
-          type: string
-      - in: query
-        name: dbt_version__in
-        schema:
-          type: array
-      - in: query
-        name: deferring_run_id
-        schema:
-          type: integer
-      - in: query
-        name: environment_id
-        schema:
-          type: integer
-      - in: query
-        name: finished_at__range
-        schema:
-          type: array
-      - in: query
-        name: has_docs_generated
-        schema:
-          type: boolean
-      - in: query
-        name: has_sources_generated
-        schema:
-          type: boolean
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: id__gt
-        schema:
-          type: integer
-      - in: query
-        name: job_definition_id
-        schema:
-          type: integer
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
-      - in: query
-        name: status
-        schema:
-          type: integer
-      - in: query
-        name: status__in
-        schema:
-          type: array
       tags:
       - Runs
       security:
@@ -1994,11 +1490,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            text/html:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v2/accounts/{account_id}/runs/{run_id}/cancel/:
     post:
       operationId: Cancel Run
@@ -2047,11 +1539,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
     post:
       operationId: Retry Run
       description: Use this endpoint to retry a failed run. When this endpoint returns
@@ -2075,11 +1563,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v2/accounts/{account_id}/steps/{id}/:
     get:
       operationId: Retrieve Run Step
@@ -2138,40 +1622,16 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v2/users/{id}/:
     get:
       operationId: Retrieve User
       parameters:
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Users
       security:
@@ -2705,17 +2165,6 @@ components:
         * `days_of_week` - days_of_week
         * `custom_cron` - custom_cron
         * `interval_cron` - interval_cron
-    Defaults:
-      type: object
-      properties:
-        data:
-          type: object
-          additionalProperties: {}
-        status:
-          $ref: '#/components/schemas/Status'
-      required:
-      - data
-      - status
     EnvironmentV2:
       type: object
       required:
@@ -2967,11 +2416,16 @@ components:
           default: 1
           description: A value of 1 means this entity is active and a value of 2 means
             this entity is deleted
+        writable_environment_categories:
+          type: array
+          items:
+            type: string
       required:
       - account_id
       - all_projects
       - group_id
       - permission_set
+      - writable_environment_categories
     HumanReadableJobDefinition:
       type: object
       required:
@@ -3632,18 +3086,6 @@ components:
       required:
       - data
       - status
-    LogLocationEnum:
-      enum:
-      - legacy
-      - s3
-      - db
-      - empty
-      type: string
-      description: |-
-        * `legacy` - legacy
-        * `s3` - s3
-        * `db` - db
-        * `empty` - empty
     PermissionSetEnum:
       enum:
       - owner
@@ -4161,8 +3603,6 @@ components:
           type: array
           items:
             type: integer
-        scribe_enabled:
-          type: boolean
         is_running:
           type: boolean
       required:
@@ -4176,7 +3616,6 @@ components:
       - job_definition_id
       - notifications_sent
       - project_id
-      - scribe_enabled
       - status
     RunResponse:
       type: object
@@ -4223,8 +3662,6 @@ components:
           type: array
           items:
             type: integer
-        scribe_enabled:
-          type: boolean
         created_at:
           type: string
           format: date-time
@@ -4327,17 +3764,10 @@ components:
           type: string
         debug_logs:
           type: string
-        log_location:
-          allOf:
-          - $ref: '#/components/schemas/LogLocationEnum'
-          default: db
         log_path:
           type: string
         debug_log_path:
           type: string
-        log_archive_type:
-          type: string
-          default: db_flushed
         truncated_debug_logs:
           type: string
           readOnly: true
@@ -4439,8 +3869,7 @@ components:
         dbt_version_override:
           type: string
           minLength: 1
-          description: 'Allowed values are: 1.0.0, 1.1.0-latest, 1.2.0-latest, 1.3.0-latest,
-            1.4.0-latest, 1.5.0-latest, 1.6.0-latest, 1.7.0-latest'
+          description: 'Allowed values are: '
         threads_override:
           type: integer
         target_name_override:

--- a/openapi-v3.yaml
+++ b/openapi-v3.yaml
@@ -89,11 +89,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v3/accounts/{account_id}/audit-logs/:
     get:
       operationId: List Recent Audit Log Events
@@ -137,11 +133,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v3/accounts/{account_id}/audit-logs/export/:
     get:
       operationId: Get Bulk Audit Log Export Status
@@ -161,11 +153,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
     post:
       operationId: Submit Bulk Audit Log Export Request
       description: |-
@@ -184,11 +172,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v3/accounts/{account_id}/audit-logs/export/{job_id}/download/:
     get:
       operationId: Download Bulk Audit Log Export
@@ -213,11 +197,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v3/accounts/{account_id}/group-permissions/{group_id}/:
     post:
       operationId: Assign Group Permissions
@@ -238,11 +218,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v3/accounts/{account_id}/groups/:
     get:
       operationId: List Groups
@@ -326,9 +302,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/GroupEnveloped'
+                $ref: '#/components/schemas/GroupEnveloped'
           description: ''
   /api/v3/accounts/{account_id}/groups/{id}/:
     get:
@@ -339,43 +313,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: name
-        schema:
-          type: string
-      - in: query
-        name: name__icontains
-        schema:
-          type: string
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: pk__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Groups
       security:
@@ -540,11 +482,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v3/accounts/{account_id}/ip-restrictions-set/{id}/validate/:
     get:
       operationId: Validate Client IP Against IP Restrictions
@@ -765,9 +703,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/LicenseMapEnveloped'
+                $ref: '#/components/schemas/LicenseMapEnveloped'
           description: ''
   /api/v3/accounts/{account_id}/license-maps/{id}/:
     get:
@@ -778,31 +714,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - License Maps
       security:
@@ -858,31 +774,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - License Maps
       security:
@@ -995,9 +891,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ProjectEnveloped'
+                $ref: '#/components/schemas/ProjectEnveloped'
           description: ''
   /api/v3/accounts/{account_id}/projects/{id}/:
     get:
@@ -1009,39 +903,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: name__icontains
-        schema:
-          type: string
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: pk__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Projects
       security:
@@ -1099,39 +965,11 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: name__icontains
-        schema:
-          type: string
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: pk__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Projects
       security:
@@ -1176,9 +1014,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DbtAdapterEnveloped'
+                $ref: '#/components/schemas/DbtAdapterEnveloped'
           description: ''
   /api/v3/accounts/{account_id}/projects/{project_id}/adapters/{id}/:
     get:
@@ -1190,44 +1026,16 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Adapters
       security:
@@ -1290,44 +1098,16 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Adapters
       security:
@@ -1426,9 +1206,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/BaseConnectionV3Enveloped'
+                $ref: '#/components/schemas/BaseConnectionV3Enveloped'
           description: ''
   /api/v3/accounts/{account_id}/projects/{project_id}/connections/{id}/:
     get:
@@ -1440,44 +1218,16 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Connections
       security:
@@ -1540,44 +1290,16 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Connections
       security:
@@ -1595,50 +1317,18 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Credentials
       security:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
     post:
       operationId: Create Projects Credential
       description: Create new credentials
@@ -1659,11 +1349,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v3/accounts/{account_id}/projects/{project_id}/credentials/{id}/:
     get:
       operationId: Retrieve Projects Credential
@@ -1674,55 +1360,23 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Credentials
       security:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
     post:
       operationId: Updates Project Credentials
       description: Update a set of credentials
@@ -1748,11 +1402,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
     patch:
       operationId: Partial Update Projects Credential
       description: Partially update a set of credentials
@@ -1762,55 +1412,23 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Credentials
       security:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
     delete:
       operationId: Destroy Projects Credential
       description: Delete a set of credentials
@@ -1820,44 +1438,16 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Credentials
       security:
@@ -1900,9 +1490,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CustomEnvironmentVariableEnveloped'
+                $ref: '#/components/schemas/CustomEnvironmentVariableEnveloped'
           description: ''
   /api/v3/accounts/{account_id}/projects/{project_id}/environment-variables/{id}/:
     post:
@@ -1954,64 +1542,16 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: environment_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: job_definition_id
-        schema:
-          type: integer
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: name
-        schema:
-          type: string
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
-      - in: query
-        name: type
-        schema:
-          type: string
-      - in: query
-        name: user_id
-        schema:
-          type: integer
       tags:
       - Environment Variables
       security:
@@ -2474,9 +2014,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/EnvironmentV3Enveloped'
+                $ref: '#/components/schemas/EnvironmentV3Enveloped'
           description: ''
   /api/v3/accounts/{account_id}/projects/{project_id}/environments/{id}/:
     get:
@@ -2488,84 +2026,16 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: credentials_id
-        schema:
-          type: integer
-      - in: query
-        name: dbt_version
-        schema:
-          type: string
-      - in: query
-        name: dbt_version__in
-        schema:
-          type: array
-      - in: query
-        name: deployment_type
-        schema:
-          type: string
-      - in: query
-        name: deployment_type__in
-        schema:
-          type: array
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: id__gt
-        schema:
-          type: integer
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: name
-        schema:
-          type: string
-      - in: query
-        name: name__icontains
-        schema:
-          type: string
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: pk__in
-        schema:
-          type: array
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
-      - in: query
-        name: type
-        schema:
-          type: string
       tags:
       - Environments
       security:
@@ -2628,84 +2098,16 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: credentials_id
-        schema:
-          type: integer
-      - in: query
-        name: dbt_version
-        schema:
-          type: string
-      - in: query
-        name: dbt_version__in
-        schema:
-          type: array
-      - in: query
-        name: deployment_type
-        schema:
-          type: string
-      - in: query
-        name: deployment_type__in
-        schema:
-          type: array
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: id__gt
-        schema:
-          type: integer
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: name
-        schema:
-          type: string
-      - in: query
-        name: name__icontains
-        schema:
-          type: string
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: pk__in
-        schema:
-          type: array
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
-      - in: query
-        name: type
-        schema:
-          type: string
       tags:
       - Environments
       security:
@@ -2749,9 +2151,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ExtendedAttributesEnveloped'
+                $ref: '#/components/schemas/ExtendedAttributesEnveloped'
           description: ''
   /api/v3/accounts/{account_id}/projects/{project_id}/extended-attributes/{id}/:
     get:
@@ -2764,36 +2164,16 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Extended Attributes
       security:
@@ -2814,36 +2194,16 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Extended Attributes
       requestBody:
@@ -2876,36 +2236,16 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Extended Attributes
       security:
@@ -2933,11 +2273,7 @@ paths:
       - BearerAuthentication: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Defaults'
-          description: ''
+          description: No response body
   /api/v3/accounts/{account_id}/projects/{project_id}/managed-repositories/:
     post:
       operationId: Create Managed Repository
@@ -3059,9 +2395,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RepositoryV3Enveloped'
+                $ref: '#/components/schemas/RepositoryV3Enveloped'
           description: ''
   /api/v3/accounts/{account_id}/projects/{project_id}/repositories/{id}/:
     get:
@@ -3073,48 +2407,16 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: remote_url
-        schema:
-          type: string
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Repositories
       security:
@@ -3177,48 +2479,16 @@ paths:
         schema:
           type: integer
         required: true
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
       - in: path
         name: project_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: project_id__in
-        schema:
-          type: array
-      - in: query
-        name: remote_url
-        schema:
-          type: string
-      - in: query
-        name: state
-        schema:
-          type: integer
       tags:
       - Repositories
       security:
@@ -3770,39 +3040,11 @@ paths:
       operationId: List Users Credential
       description: List the development credentials associated with a given user.
       parameters:
-      - in: query
-        name: account_id
-        schema:
-          type: integer
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: state
-        schema:
-          type: integer
       - in: path
         name: user_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: user_id
-        schema:
-          type: integer
       tags:
       - Users
       security:
@@ -3851,44 +3093,16 @@ paths:
       operationId: Retrieve Users Credential
       description: Get a development credentials association for a given user.
       parameters:
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: state
-        schema:
-          type: integer
       - in: path
         name: user_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: user_id
-        schema:
-          type: integer
       tags:
       - Users
       security:
@@ -3942,44 +3156,16 @@ paths:
       operationId: Destroy Users Credential
       description: Delete a development credentials / user association.
       parameters:
-      - in: query
-        name: account_id
-        schema:
-          type: integer
       - in: path
         name: id
         schema:
           type: integer
         required: true
-      - in: query
-        name: limit
-        schema:
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          type: integer
-      - in: query
-        name: pk
-        schema:
-          type: integer
-      - in: query
-        name: project_id
-        schema:
-          type: integer
-      - in: query
-        name: state
-        schema:
-          type: integer
       - in: path
         name: user_id
         schema:
           type: integer
         required: true
-      - in: query
-        name: user_id
-        schema:
-          type: integer
       tags:
       - Users
       security:
@@ -4593,17 +3779,6 @@ components:
       - adapter_version
       - metadata_json
       - project_id
-    Defaults:
-      type: object
-      properties:
-        data:
-          type: object
-          additionalProperties: {}
-        status:
-          $ref: '#/components/schemas/Status'
-      required:
-      - data
-      - status
     DeleteSubscriptionResponseData:
       type: object
       properties:
@@ -4999,11 +4174,16 @@ components:
           default: 1
           description: A value of 1 means this entity is active and a value of 2 means
             this entity is deleted
+        writable_environment_categories:
+          type: array
+          items:
+            type: string
       required:
       - account_id
       - all_projects
       - group_id
       - permission_set
+      - writable_environment_categories
     GroupRequest:
       type: object
       properties:
@@ -6050,8 +5230,6 @@ components:
           type: array
           items:
             type: integer
-        scribe_enabled:
-          type: boolean
         is_running:
           type: boolean
       required:
@@ -6065,7 +5243,6 @@ components:
       - job_definition_id
       - notifications_sent
       - project_id
-      - scribe_enabled
       - status
     Schema:
       type: object


### PR DESCRIPTION
Lots of lines removed because we were erroneously showing filter params on _everything_ that wasn't a `POST`. We only actually want the filter params showing for `GET` requests that are returning a list. Basically the `GET` and `DELETE` requests that operate on a single `{id}` should not be showing filters in the docs.

The following is an example of our current live doc where the filter will be removed.
![Screenshot 2024-05-01 at 10 25 14 AM](https://github.com/dbt-labs/dbt-cloud-openapi-spec/assets/5863865/354c6877-9c48-41e6-b45b-e2b03bf74de8)
